### PR TITLE
remove 'fstab.yaml' from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 coverage/*
 logs/*
 node_modules/*
-fstab.yaml
 
 helix-importer-ui
 .DS_Store

--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,0 +1,5 @@
+mountpoints:
+  /:
+    url: "https://author-p145105-e1492662.adobeaemcloud.com/bin/franklin.delivery/mrvengenharia/meusensia/main"
+    type: "markup"
+    suffix: ".html"


### PR DESCRIPTION
Allow fstab to exist 🥇 

Test URLs:
- Before: https://main--mrvcopy--helms-charity.aem.page
- After: https://main--mrvcopy--helms-charity.aem.page
